### PR TITLE
Hh.ppe.n08 ctsm5.1.dev023

### DIFF
--- a/src/biogeophys/BareGroundFluxesMod.F90
+++ b/src/biogeophys/BareGroundFluxesMod.F90
@@ -329,7 +329,7 @@ contains
 
             tstar = temp1(p)*dth(p)
             qstar = temp2(p)*dqh(p)
-            z0hg_patch(p) = z0mg_patch(p) / exp(col%a_coef(c) * (ustar(p) * z0mg_patch(p) / 1.5e-5_r8)**params_inst%a_exp)
+            z0hg_patch(p) = z0mg_patch(p) / exp(col%a_coef(c) * (ustar(p) * z0mg_patch(p) / 1.5e-5_r8)**col%a_exp(c))
             z0qg_patch(p) = z0hg_patch(p)
             thvstar = tstar*(1._r8+0.61_r8*forc_q(c)) + 0.61_r8*forc_th(c)*qstar
             zeta = zldis(p)*vkc*grav*thvstar/(ustar(p)**2*thv(c))

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1011,7 +1011,7 @@ bioms:   do f = 1, fn
             ! changed by K.Sakaguchi from here
             ! transfer coefficient over bare soil is changed to a local variable
             ! just for readability of the code (from line 680)
-            csoilb = vkc / (col%a_coef(c) * (z0mg(c) * uaf(p) / 1.5e-5_r8)**params_inst%a_exp)
+            csoilb = vkc / (col%a_coef(c) * (z0mg(c) * uaf(p) / 1.5e-5_r8)**col%a_exp(c))
 
             !compute the stability parameter for ricsoilc  ("S" in Sakaguchi&Zeng,2008)
 

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -315,6 +315,8 @@ contains
      ! Compute runoff from canopy due to exceeding maximum storage, for bulk
      call BulkFlux_CanopyExcess(bounds, num_soilp, filter_soilp, &
           ! Inputs
+          patch = patch, &
+          col   = col, &
           dtime = dtime, &
           elai = canopystate_inst%elai_patch(begp:endp), &
           esai = canopystate_inst%esai_patch(begp:endp), &
@@ -707,6 +709,7 @@ contains
 
    !-----------------------------------------------------------------------
    subroutine BulkFlux_CanopyExcess(bounds, num_soilp, filter_soilp, &
+        patch, col, &
         dtime, elai, esai, snocan, liqcan, &
         check_point_for_interception_and_excess, &
         qflx_snocanfall, qflx_liqcanfall)
@@ -718,6 +721,8 @@ contains
      type(bounds_type), intent(in) :: bounds
      integer, intent(in) :: num_soilp
      integer, intent(in) :: filter_soilp(:)
+     type(patch_type), intent(in) :: patch
+     type(column_type), intent(in) :: col
 
      real(r8) , intent(in)    :: dtime                                                   ! land model time step (sec)
      real(r8) , intent(in)    :: elai( bounds%begp: )                                    ! canopy one-sided leaf area index with burying by snow
@@ -731,7 +736,7 @@ contains
      real(r8) , intent(inout) :: qflx_liqcanfall( bounds%begp: )                         ! rate of excess canopy liquid falling off canopy (mm H2O/s)
      !
      ! !LOCAL VARIABLES:
-     integer :: fp, p
+     integer :: fp, p, c
      real(r8) :: snocanmx ! maximum allowed snow on canopy (mm H2O)
      real(r8) :: liqcanmx ! maximum allowed liquid water on canopy (mm H2O)
 
@@ -748,11 +753,12 @@ contains
 
      do fp = 1, num_soilp
         p = filter_soilp(fp)
+        c = patch%column(p)
         qflx_liqcanfall(p) = 0._r8
         qflx_snocanfall(p) = 0._r8
 
         if (check_point_for_interception_and_excess(p)) then
-           liqcanmx = params_inst%liq_canopy_storage_scalar * (elai(p) + esai(p))
+           liqcanmx = col%liq_canopy_storage_scalar(c) * (elai(p) + esai(p))
            qflx_liqcanfall(p) = max((liqcan(p) - liqcanmx)/dtime, 0._r8)
            snocanmx = params_inst%snow_canopy_storage_scalar * (elai(p) + esai(p))
            qflx_snocanfall(p) = max((snocan(p) - snocanmx)/dtime, 0._r8)

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -422,6 +422,8 @@ contains
      ! is dry and transpiring.
      call BulkDiag_FracWet(bounds, num_soilp, filter_soilp, &
           ! Inputs
+          patch                 = patch, &
+          col                   = col, &
           frac_veg_nosno = canopystate_inst%frac_veg_nosno_patch(begp:endp), &
           elai           = canopystate_inst%elai_patch(begp:endp), &
           esai           = canopystate_inst%esai_patch(begp:endp), &
@@ -1113,6 +1115,7 @@ contains
 
    !-----------------------------------------------------------------------
    subroutine BulkDiag_FracWet(bounds, num_soilp, filter_soilp, &
+        patch, col, &
         frac_veg_nosno, elai, esai, snocan, liqcan, &
         fwet, fdry, fcansno)
      !
@@ -1130,6 +1133,8 @@ contains
      type(bounds_type), intent(in) :: bounds
      integer, intent(in) :: num_soilp
      integer, intent(in) :: filter_soilp(:)
+     type(patch_type), intent(in) :: patch
+     type(column_type), intent(in) :: col
 
      integer  , intent(in)    :: frac_veg_nosno( bounds%begp: ) ! fraction of vegetation not covered by snow (0 OR 1)
      real(r8) , intent(in)    :: elai( bounds%begp: )           ! canopy one-sided leaf area index with burying by snow
@@ -1141,7 +1146,7 @@ contains
      real(r8) , intent(inout) :: fcansno( bounds%begp: )        ! fraction of canopy that is snow covered (0 to 1)
      !
      ! !LOCAL VARIABLES:
-     integer  :: fp,p             ! indices
+     integer  :: fp,p,c           ! indices
      real(r8) :: h2ocan           ! total canopy water (mm H2O)
      real(r8) :: vegt             ! lsai
      !-----------------------------------------------------------------------
@@ -1157,12 +1162,13 @@ contains
 
      do fp = 1, num_soilp
         p = filter_soilp(fp)
+        c = patch%column(p)
         if (frac_veg_nosno(p) == 1) then
            h2ocan = snocan(p) + liqcan(p)
 
            if (h2ocan > 0._r8) then
               vegt    = frac_veg_nosno(p)*(elai(p) + esai(p))
-              fwet(p) = (h2ocan / (vegt * params_inst%liq_canopy_storage_scalar))**0.666666666666_r8
+              fwet(p) = (h2ocan / (vegt * col%liq_canopy_storage_scalar(c)))**0.666666666666_r8
               fwet(p) = min (fwet(p),maximum_leaf_wetted_fraction)   ! Check for maximum limit of fwet
               if (snocan(p) > 0._r8) then
                  fcansno(p) = (snocan(p) / (vegt * params_inst%snow_canopy_storage_scalar))**0.15_r8 ! must match snocanmx 

--- a/src/biogeophys/HillslopeHydrologyMod.F90
+++ b/src/biogeophys/HillslopeHydrologyMod.F90
@@ -395,13 +395,13 @@ contains
     endif
     if ( allocated(hill_pftndx) ) then
        deallocate(hill_pftndx)
-       call HillslopePftFromFile()
+!       call HillslopePftFromFile()
     else
        ! Modify pft distributions
        ! this may require modifying subgridMod/natveg_patch_exists
        ! to ensure patch exists in every gridcell
 
-       call HillslopeDominantPft()
+!       call HillslopeDominantPft()
     
        !upland_ivt  = 13 ! c3 non-arctic grass
        !lowland_ivt = 7  ! broadleaf deciduous tree 

--- a/src/biogeophys/LakeFluxesMod.F90
+++ b/src/biogeophys/LakeFluxesMod.F90
@@ -325,11 +325,11 @@ contains
             z0hg(p) = max(z0hg(p), minz0lake)
          else if (snl(c) == 0) then    ! frozen lake with ice
             z0mg(p) = z0frzlake
-            z0hg(p) = z0mg(p) / exp(col%a_coef(c) * (ust_lake(c) * z0mg(p) / 1.5e-5_r8)**params_inst%a_exp) ! Consistent with BareGroundFluxes
+            z0hg(p) = z0mg(p) / exp(col%a_coef(c) * (ust_lake(c) * z0mg(p) / 1.5e-5_r8)**col%a_exp(c)) ! Consistent with BareGroundFluxes
             z0qg(p) = z0hg(p)
          else                          ! use roughness over snow as in Biogeophysics1
             z0mg(p) = params_inst%zsno
-            z0hg(p) = z0mg(p) / exp(col%a_coef(c) * (ust_lake(c) * z0mg(p) / 1.5e-5_r8)**params_inst%a_exp)  ! Consistent with BareGroundFluxes
+            z0hg(p) = z0mg(p) / exp(col%a_coef(c) * (ust_lake(c) * z0mg(p) / 1.5e-5_r8)**col%a_exp(c))  ! Consistent with BareGroundFluxes
             z0qg(p) = z0hg(p)
          end if
 
@@ -546,11 +546,11 @@ contains
             else if (snl(c) == 0) then
                ! in case it was above freezing and now below freezing
                z0mg(p) = z0frzlake
-               z0hg(p) = z0mg(p) / exp(col%a_coef(c) * (ustar(p) * z0mg(p) / 1.5e-5_r8)**params_inst%a_exp) ! Consistent with BareGroundFluxes
+               z0hg(p) = z0mg(p) / exp(col%a_coef(c) * (ustar(p) * z0mg(p) / 1.5e-5_r8)**col%a_exp(c)) ! Consistent with BareGroundFluxes
                z0qg(p) = z0hg(p)
             else ! Snow layers
                ! z0mg won't have changed
-               z0hg(p) = z0mg(p) / exp(col%a_coef(c) * (ustar(p) * z0mg(p) / 1.5e-5_r8)**params_inst%a_exp) ! Consistent with BareGroundFluxes
+               z0hg(p) = z0mg(p) / exp(col%a_coef(c) * (ustar(p) * z0mg(p) / 1.5e-5_r8)**col%a_exp(c)) ! Consistent with BareGroundFluxes
                z0qg(p) = z0hg(p)
             end if
 

--- a/src/main/ColumnType.F90
+++ b/src/main/ColumnType.F90
@@ -95,6 +95,9 @@ module ColumnType
      real(r8), pointer :: a_coef               (:)   ! Drag coefficient under less dense canopy (unitless)
      real(r8), pointer :: vcmaxha              (:)   ! Activation energy for vcmax (J/mol) 
      real(r8), pointer :: cv                   (:)   ! Turbulent transfer coeff. between canopy surface and canopy air (m/s^(1/2))
+     real(r8), pointer :: a_exp                (:)   ! Drag exponent under less dense canopy
+     real(r8), pointer :: liq_canopy_storage_scalar (:)   ! Maximum storage of liquid water on leaf surface
+
      ! levgrnd_class gives the class in which each layer falls. This is relevant for
      ! columns where there are 2 or more fundamentally different layer types. For
      ! example, this distinguishes between soil and bedrock layers. The particular value
@@ -183,6 +186,8 @@ contains
     allocate(this%a_coef      (begc:endc))                     ; this%a_coef      (:)   = spval
     allocate(this%vcmaxha     (begc:endc))                     ; this%vcmaxha     (:)   = spval
     allocate(this%cv          (begc:endc))                     ; this%cv          (:)   = spval
+    allocate(this%a_exp       (begc:endc))                     ; this%a_exp       (:)   = spval
+    allocate(this%liq_canopy_storage_scalar(begc:endc))        ; this%liq_canopy_storage_scalar(:) = spval
   end subroutine Init
 
   !------------------------------------------------------------------------
@@ -242,6 +247,8 @@ contains
     deallocate(this%a_coef     )
     deallocate(this%vcmaxha    )
     deallocate(this%cv         )
+    deallocate(this%a_exp      )
+    deallocate(this%liq_canopy_storage_scalar)
   end subroutine Clean
 
   !-----------------------------------------------------------------------

--- a/src/main/initVerticalMod.F90
+++ b/src/main/initVerticalMod.F90
@@ -57,6 +57,8 @@ module initVerticalMod
      real(r8) :: a_coef         ! Drag coefficient under less dense canopy (unitless)
      real(r8) :: vcmaxha        ! Activation energy for vcmax (J/mol)
      real(r8) :: cv             ! Turbulent transfer coeff. between canopy surface and canopy air (m/s^(1/2)) 
+     real(r8) :: a_exp          ! Drag coefficient under less dense canopy (unitless)
+     real(r8) :: liq_canopy_storage_scalar ! Maximum storage of liquid water on leaf surface
   end type params_type
   type(params_type), private ::  params_inst
   !
@@ -99,6 +101,8 @@ contains
     call readNcdioScalar(ncid, 'a_coef'   , subname, params_inst%a_coef)
     call readNcdioScalar(ncid, 'vcmaxha'  , subname, params_inst%vcmaxha)
     call readNcdioScalar(ncid, 'cv'       , subname, params_inst%cv)
+    call readNcdioScalar(ncid, 'a_exp'    , subname, params_inst%a_exp)
+    call readNcdioScalar(ncid, 'liq_canopy_storage_scalar', subname, params_inst%liq_canopy_storage_scalar)
   end subroutine readParams
 
   !------------------------------------------------------------------------
@@ -153,6 +157,8 @@ contains
     real(r8) ,pointer     :: acc_vcmaxha   (:) ! read in params - vcmaxha
     real(r8) ,pointer     :: sen_cv        (:) ! read in params - cv
     real(r8) ,pointer     :: temp_krmax            (:,:) ! read in params - krmax
+    real(r8) ,pointer     :: sen_a_exp     (:) ! read in params - a_exp
+    real(r8) ,pointer     :: hydro_liq_can (:) ! read in params - liq_canopy_storage_scalar
 
     ! Possible values for levgrnd_class. The important thing is that, for a given column,
     ! layers that are fundamentally different (e.g., soil vs bedrock) have different
@@ -925,6 +931,36 @@ contains
        write(iulog,*) "source of param - cv is: surface data file"
     end if
     deallocate(sen_cv)
+
+    ! read in a_exp
+    allocate(sen_a_exp(bounds%begg:bounds%endg))
+    call ncd_io(ncid=ncid, varname='a_exp', flag='read', data=sen_a_exp, dim1name=grlnd, readvar=readvar)
+    if (.not. readvar) then
+       col%a_exp(:) = params_inst%a_exp
+       write(iulog,*) "source of param - a_exp is: parameter file"
+    else
+       do c = begc,endc
+          g = col%gridcell(c)
+          col%a_exp(c) = sen_a_exp(g)
+       end do
+       write(iulog,*) "source of param - a_exp is: surface data file"
+    end if
+    deallocate(sen_a_exp)
+
+    ! read in a_exp
+    allocate(hydro_liq_can(bounds%begg:bounds%endg))
+    call ncd_io(ncid=ncid, varname='liq_canopy_storage_scalar', flag='read', data=hydro_liq_can, dim1name=grlnd, readvar=readvar)
+    if (.not. readvar) then
+       col%liq_canopy_storage_scalar(:) = params_inst%liq_canopy_storage_scalar
+       write(iulog,*) "source of liq_canopy_storage_scalar - a_exp is: parameter file"
+    else
+       do c = begc,endc
+          g = col%gridcell(c)
+          col%liq_canopy_storage_scalar(c) = hydro_liq_can(g)
+       end do
+       write(iulog,*) "source of param - liq_canopy_storage_scalar is: surface data file"
+    end if
+    deallocate(hydro_liq_can)
 
     !-----------------------------------------------
     ! SCA shape function defined


### PR DESCRIPTION
### Description of changes
This pull request mainly includes two changes:
1) we used the default natural pft instead of using prescribed pft from hillslope hydrology
2) add two spatially distributed parameters - a_exp and liq_canopy_storage_scalar

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #): 

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
